### PR TITLE
fix: 选取目标点顺序错误

### DIFF
--- a/ui/drawscreen.py
+++ b/ui/drawscreen.py
@@ -82,22 +82,23 @@ def drawguideline(screen : pygame.Surface) -> None:
             nowx,nowy = pygame.mouse.get_pos()
             nowdata = getdata()
             for i in nowdata["node"]:
-                if nowtouching.type=="NewNode" or ( i.id != nowtouching.args["id"] and nowtouching.type=="Node"):
-                    x, y = databasexytoscreenxy(i.x, i.y)
-                    if abs(x-nowx) < abs(nowx-verticallinex):
-                        verticallinex = x
-                        verticallinenode = i
-                    if abs(y-nowy) < abs(nowy-horizontalliney):
-                        horizontalliney = y
-                        horizontallinenode = i
+                if inscreen(*databasexytoscreenxy(i.x, i.y)):
+                    if nowtouching.type=="NewNode" or ( i.id != nowtouching.args["id"] and nowtouching.type=="Node"):
+                        x, y = databasexytoscreenxy(i.x, i.y)
+                        if abs(x-nowx) < abs(nowx-verticallinex):
+                            verticallinex = x
+                            verticallinenode = i
+                        if abs(y-nowy) < abs(nowy-horizontalliney):
+                            horizontalliney = y
+                            horizontallinenode = i
         except:
             raise DrawError("尝试计算辅助线时出错")
         try:
-            if abs(nowx-verticallinex) < nowGLSD and verticallinenode and inscreen(*databasexytoscreenxy(verticallinenode.x, verticallinenode.y)):
+            if abs(nowx-verticallinex) < nowGLSD and verticallinenode:
                 pygame.draw.line(screen, (0, 255, 255), (verticallinex, 0), (verticallinex, getheight()), 2)
             else:
                 verticallinenode = None
-            if abs(nowy-horizontalliney) < nowGLSD and horizontallinenode and inscreen(*databasexytoscreenxy(horizontallinenode.x, horizontallinenode.y)):
+            if abs(nowy-horizontalliney) < nowGLSD and horizontallinenode:
                 pygame.draw.line(screen, (0, 255, 255), (0, horizontalliney), (getwidth(), horizontalliney), 2)
             else:
                 horizontallinenode = None


### PR DESCRIPTION
准确描述此bug:
原代码选取顺序：先由距离绝对值取最小，然后判断是否在屏幕内。
如有2点A,B，A距离更近，但是B也在范围之内，A不在屏幕内，B在。原来的代码会不绘制辅助线，因为A点在屏幕外，但此时正确应过B绘制辅助线 新代码在取最小值之前就先判断是否在屏幕范围之内